### PR TITLE
Compute Ip from area integral by default

### DIFF
--- a/src/canvas.jl
+++ b/src/canvas.jl
@@ -62,6 +62,8 @@ mutable struct Canvas{T<:Real, VC<:CoilVectorType, II<:Interpolations.AbstractIn
     _Fpol_itp::DI
     _rho::Vector{T}
     _rho_itp::DI
+    _area::Vector{T}
+    _area_itp::DI
     _r_cache::Vector{T}
     _z_cache::Vector{T}
 end
@@ -273,6 +275,7 @@ function Canvas(Rs::AbstractRange{T},
     gm9 = zero(x)
     Fpol = zero(x)
     rho = zero(x)
+    area = zero(x)
     zitp = DataInterpolations.CubicSpline(zero(x), x; extrapolation=ExtrapolationType.None)
 
 
@@ -282,8 +285,8 @@ function Canvas(Rs::AbstractRange{T},
                   iso_cps, flux_cps, saddle_cps,
                   vs_circuit, rs_circuit, Ψ_at_coils, tmp_Ncoils, fixed_coils, mutuals, mutuals_LU, a, b, c, MST, u,
                   A, B, M, LU, S, tmp_Ψ,
-                  surfaces, Vp, deepcopy(zitp), gm1, deepcopy(zitp), gm2p, deepcopy(zitp),
-                  gm9, deepcopy(zitp), Fpol, deepcopy(zitp), rho, deepcopy(zitp), r_cache, z_cache)
+                  surfaces, Vp, deepcopy(zitp), gm1, deepcopy(zitp), gm2p, deepcopy(zitp), gm9, deepcopy(zitp),
+                  Fpol, deepcopy(zitp), rho, deepcopy(zitp), area, deepcopy(zitp), r_cache, z_cache)
 end
 
 function bnd2mat(Nr::Int, Nz::Int, k::Int)


### PR DESCRIPTION
FRESCO would scales either FF' or <Jt/R> to make the plasma current equal the desired current (`canvas.Ip`). For `PressureJt` or `PressureJtoR` profiles, the Ip at each iteration was compute as the integral of _dpsi * dV/psi * <Jt/R>_. For a `PprimeFFprime` profile, the Ip was computed from a 2D area integral over the grid. In IMAS, on the other hand, the plasma current is computed as the 1D area integral of _<Jt/R> / <1/R>_. All of these are formally correct, but can give slightly different answers due to resolution. Thus the Ip in the dd after  ActorFRESCO could be slightly different than the requested Ip.

This pull request has FRESCO compute the area, then do the integral the same was as IMAS. This is the default behavior and improves consistency between FRESCO and IMAS. There is an option to use the 2D grid integration, which restores the old behavior for `PprimeFFprime` profiles. Note that that would be new behavior for `PressureJt` or `PressureJtoR` profiles. The old volume integral approach for `PressureJt` or `PressureJtoR` profiles is no longer supported.

@lstagner may be interested.