### PR TITLE
limit psi_norm between 0 and 1

### DIFF
--- a/src/flux_surfaces.jl
+++ b/src/flux_surfaces.jl
@@ -38,7 +38,7 @@ function flux_bounds!(canvas::Canvas; update_Ψitp::Bool=true)
     return canvas.Raxis, canvas.Zaxis, canvas.Ψaxis, canvas.Ψbnd = Raxis, Zaxis, Ψaxis, Ψbnd
 end
 
-psinorm(psi::Real, canvas::Canvas) = (psi - canvas.Ψaxis) / (canvas.Ψbnd - canvas.Ψaxis)
+psinorm(psi::Real, canvas::Canvas) = max(0.0, min(1.0, (psi - canvas.Ψaxis) / (canvas.Ψbnd - canvas.Ψaxis)))
 psinorm(canvas::Canvas) = range(0.0, 1.0, length(canvas._surfaces))
 
 function boundary!(canvas::Canvas)


### PR DESCRIPTION
I had some cases where psi_norm was a very small negative number (e^-16) and that would break the interpolation because it is done with `extrapolation=ExtrapolationType.None`