### PR TITLE
Clamp psinorm to [0,1] to prevent extrapolation crashes

### DIFF
--- a/src/current.jl
+++ b/src/current.jl
@@ -282,7 +282,7 @@ function Jtor!(canvas::Canvas, profile::PprimeFFprime; update_surfaces::Bool, co
         for (i,R) in enumerate(Rs)
             for j in eachindex(Zs)
                 if is_inside[i, j]
-                    psin = psinorm(Ψ[i, j], canvas)
+                    psin = clamp(psinorm(Ψ[i, j], canvas), 0.0, 1.0)
                     x = get_x(canvas, profile, psin)
                     Jt[i, j] = -twopi * FFprime(canvas, profile, psin, x) / (R * μ₀)
                 end
@@ -294,7 +294,7 @@ function Jtor!(canvas::Canvas, profile::PprimeFFprime; update_surfaces::Bool, co
         for (i,R) in enumerate(Rs)
             for j in eachindex(Zs)
                 if is_inside[i, j]
-                    psin = psinorm(Ψ[i, j], canvas)
+                    psin = clamp(psinorm(Ψ[i, j], canvas), 0.0, 1.0)
                     x = get_x(canvas, profile, psin)
                     Jt[i, j] += -twopi * R * Pprime(canvas, profile, psin, x)
                 end
@@ -328,7 +328,7 @@ function Jtor!(canvas::Canvas, profile::PprimeFFprime; update_surfaces::Bool, co
     for (i,R) in enumerate(Rs)
         for j in eachindex(Zs)
             if is_inside[i, j]
-                psin = psinorm(Ψ[i, j], canvas)
+                psin = clamp(psinorm(Ψ[i, j], canvas), 0.0, 1.0)
                 x = get_x(canvas, profile, psin)
                 Jt[i, j] = -twopi * (R * Pprime(canvas, profile, psin, x) + FFprime(canvas, profile, psin, x) / (R * μ₀))
             end
@@ -433,7 +433,7 @@ function Jtor!(canvas::Canvas, profile::Union{PressureJtoR, PressureJt}; update_
             R2 = R ^ 2
             for j in eachindex(Zs)
                 if is_inside[i, j]
-                    psin = psinorm(Ψ[i, j], canvas)
+                    psin = clamp(psinorm(Ψ[i, j], canvas), 0.0, 1.0)
                     gm1_psin = canvas._gm1_itp(psin)
                     x = get_x(canvas, profile, psin)
                     pterm = twopi * (R2 - 1.0 / gm1_psin) * Pprime(canvas, profile, psin, x)
@@ -465,7 +465,7 @@ function Jtor!(canvas::Canvas, profile::Union{PressureJtoR, PressureJt}; update_
         R2 = R ^ 2
         for j in eachindex(Zs)
             if is_inside[i, j]
-                psin = psinorm(Ψ[i, j], canvas)
+                psin = clamp(psinorm(Ψ[i, j], canvas), 0.0, 1.0)
                 gm1_psin = canvas._gm1_itp(psin)
                 x = get_x(canvas, profile, psin)
                 pterm = twopi * (R2 - 1.0 / gm1_psin) * Pprime(canvas, profile, psin, x)

--- a/src/flux_surfaces.jl
+++ b/src/flux_surfaces.jl
@@ -104,7 +104,7 @@ function in_core(r::Real, z::Real, psin::Real, canvas::Canvas,
     ellipse::Union{Nothing,AbstractVector{<:Real}}=nothing)
 
     # Check psinorm value
-    psin > 1.0 && return false
+    (psin > 1.0 || psin < 0.0) && return false
 
     # Check outside bounding box
     !in_plasma_bb(r, z, canvas) && return false


### PR DESCRIPTION
## Summary

  The magnetic axis `Ψaxis` is found from a bicubic interpolant between grid points, while actual grid values of `Ψ` can overshoot slightly past `Ψaxis`. This causes `psinorm = (Ψ - Ψaxis)/(Ψbnd - Ψaxis)` to
  go slightly negative near the axis, which crashes CubicSpline interpolations (`_gm1_itp`, `_gm9_itp`, etc.) that use `ExtrapolationType.None`.

  ### Changes
  - **`flux_surfaces.jl`**: Reject `psin < 0` in `in_core()` so grid points with negative psinorm are excluded from the plasma region
  - **`current.jl`**: Clamp psinorm to [0,1] in all `Jtor!` loops (5 locations) as a safety net for profile evaluations (P', FF', pressure, ⟨Jt/R⟩, Jt)

  ## Test plan
  - [ ] Verify FRESCO no longer crashes with CubicSpline extrapolation errors during GS solve
  - [ ] Run postdictive simulation (e.g. DIII-D 158019 reconstruction) to confirm fix